### PR TITLE
Actually descends to do nested checking, performance improvements, fix enum variant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/out
 **/*.vsix
 **/.idea
+**/*.trace/

--- a/example/data/config_complete.ron
+++ b/example/data/config_complete.ron
@@ -1,11 +1,15 @@
 /* @[crate::models::Config] */
 Config(
-    // Complete example showing all fields
     // Even though Config has Default, you can still specify all fields
     host: "localhost",
     port: 8080,
     max_connections: 100,
     debug: true,
-    api_key: Some("secret-key-123"),
-    allowed_origins: ["http://localhost:3000", "https://example.com"],
+    allowed_origins: [
+        "http://localhost:3000",
+        "https://example.com",
+    ],
+    api_key: Some(
+        "secret-key-123",
+    )
 )

--- a/example/data/enum_variants.ron
+++ b/example/data/enum_variants.ron
@@ -1,0 +1,22 @@
+/* @[crate::models::Message] */
+
+// Complex nested enum variant with Post containing User
+PostReference(Post(
+    id: 42,
+    title: "Enum Variants in RON",
+    content: "Shows tuple variants, struct variants, and nesting",
+    author: User(
+        id: 1,
+        name: "Alice",
+        email: "alice@example.com",
+        age: 30,
+        bio: Some("Rust developer"),
+        is_active: true,
+        roles: ["admin"],
+        invalid_field: "should error",
+    ),
+    likes: 100,
+    tags: ["rust", "ron"],
+    published: true,
+    post_type: Detailed( length: 1 ),
+))

--- a/example/data/enum_variants.ron
+++ b/example/data/enum_variants.ron
@@ -1,22 +1,32 @@
 /* @[crate::models::Message] */
-
 // Complex nested enum variant with Post containing User
-PostReference(Post(
-    id: 42,
-    title: "Enum Variants in RON",
-    content: "Shows tuple variants, struct variants, and nesting",
-    author: User(
-        id: 1,
-        name: "Alice",
-        email: "alice@example.com",
-        age: 30,
-        bio: Some("Rust developer"),
-        is_active: true,
-        roles: ["admin"],
-        invalid_field: "should error",
-    ),
-    likes: 100,
-    tags: ["rust", "ron"],
-    published: true,
-    post_type: Detailed( length: 1 ),
-))
+PostReference(
+    Post(
+        id: 42,
+        title: "Enum Variants in RON",
+        content: "Shows tuple variants, struct variants, and nesting",
+        author: User(
+            id: 1,
+            name: "Alice",
+            email: "alice@example.com",
+            age: 30,
+            bio: Some(
+                "Rust developer",
+            ),
+            is_active: true,
+            roles: [
+                "admin",
+            ],
+            invalid_field: "should error",
+        ),
+        likes: 100,
+        tags: [
+            "rust",
+            "ron",
+        ],
+        published: true,
+        post_type: Detailed(
+            length: 1,
+        ),
+    )
+)

--- a/example/data/error_examples.ron
+++ b/example/data/error_examples.ron
@@ -1,0 +1,36 @@
+/* @[crate::models::Status] */
+
+// UNCOMMENT THESE ONE AT A TIME TO SEE DIFFERENT DIAGNOSTICS:
+
+// 1. Valid unit variant
+Active
+
+// 2. ERROR: Unit variant with data
+// Active(123)
+// Diagnostic: "Variant 'Active' is a unit variant and cannot have data"
+
+// 3. ERROR: Unknown variant
+// Pending
+// Diagnostic: "Unknown variant 'Pending' for enum 'example::models::Status'"
+
+// 4. ERROR: Wrong type in tuple variant
+// Error("not a number")
+// Diagnostic: Type mismatch - expects u32, got string
+
+// 5. VALID: Correct tuple variant
+// Error(404)
+
+// 6. VALID: Tuple variant with string
+// Warning("Something went wrong")
+
+// 7. VALID: Struct-like variant
+// Processing {
+//     progress: 85,
+//     stage: "Finalizing",
+// }
+
+// 8. ERROR: Struct-like variant with wrong field type
+// Processing {
+//     progress: "85",  // Should be u32, not string
+//     stage: "Testing",
+// }

--- a/example/data/generic_test.ron
+++ b/example/data/generic_test.ron
@@ -1,14 +1,21 @@
 /* @[crate::models::GenericTest] */
-
 GenericTest(
     // Good: Proper Option with Some
-    good_option: Some("This is valid"),
+    good_option: Some(
+        "This is valid",
+    ),
 
     // Bad: Number instead of Option<String>
     bad_option: 12345,
 
     // Good: Proper Vec
-    good_vec: [1, 2, 3, 4, 5],
+    good_vec: [
+        1,
+        2,
+        3,
+        4,
+        5,
+    ],
 
     // Bad: Single integer instead of Vec
     bad_vec: 42,
@@ -33,13 +40,19 @@ GenericTest(
     bad_btreemap: 123,
 
     // Good: Proper HashSet
-    good_hashset: ["apple", "banana", "cherry"],
+    good_hashset: [
+        "apple",
+        "banana",
+        "cherry",
+    ],
 
     // Bad: String instead of HashSet
     bad_hashset: "not a set",
 
     // Good: Proper Result with Ok
-    good_result: Ok("Success!"),
+    good_result: Ok(
+        "Success!",
+    ),
 
     // Bad: Plain string instead of Result
     bad_result: "This should be Ok(...) or Err(...)",

--- a/example/data/mixed_syntax.ron
+++ b/example/data/mixed_syntax.ron
@@ -1,0 +1,26 @@
+/* @[crate::models::Post] */
+
+// This demonstrates mixing explicit and unnamed struct syntax
+// throughout the document
+
+Post(
+    id: 123,
+    title: "Mixed Syntax Example",
+    content: "Demonstrating both explicit and unnamed struct syntax",
+
+    // Explicit type name for author
+    author: (
+        id: 5,
+        name: "Charlie",
+        email: "charlie@example.com",
+        age: 28,
+        bio: None,
+        is_active: true,
+        roles: ["editor"],
+    ),
+
+    likes: 50,
+    tags: ["example", "syntax"],
+    published: true,
+    post_type: Short,
+)

--- a/example/data/mixed_syntax.ron
+++ b/example/data/mixed_syntax.ron
@@ -1,8 +1,7 @@
 /* @[crate::models::Post] */
-
 // This demonstrates mixing explicit and unnamed struct syntax
-// throughout the document
 
+// throughout the document
 Post(
     id: 123,
     title: "Mixed Syntax Example",
@@ -16,11 +15,15 @@ Post(
         age: 28,
         bio: None,
         is_active: true,
-        roles: ["editor"],
+        roles: [
+            "editor",
+        ],
     ),
-
     likes: 50,
-    tags: ["example", "syntax"],
+    tags: [
+        "example",
+        "syntax",
+    ],
     published: true,
     post_type: Short,
 )

--- a/example/data/nested_enum.ron
+++ b/example/data/nested_enum.ron
@@ -1,0 +1,4 @@
+/* @[crate::models::Status] */
+
+// Tuple variant with error code
+Error(404)

--- a/example/data/nested_enum.ron
+++ b/example/data/nested_enum.ron
@@ -1,4 +1,5 @@
 /* @[crate::models::Status] */
-
 // Tuple variant with error code
-Error(404)
+Error(
+    404,
+)

--- a/example/data/post.ron
+++ b/example/data/post.ron
@@ -1,12 +1,15 @@
 /* @[crate::models::Post] */
-
 Post(
     id: 101,
     title: "Getting Started with Rust",
     content: "# Introduction to Rust\n\nRust is a systems programming language...",
     author: 1,
     likes: 42.0,
-    tags: ["rust", "programming", "tutorial"],
+    tags: [
+        "rust",
+        "programming",
+        "tutorial",
+    ],
     post_type: Short,
     foo: 1,
 )

--- a/example/data/settings.ron
+++ b/example/data/settings.ron
@@ -4,6 +4,7 @@ Settings(
     // So the LSP will show warnings for missing required fields
     // Try using the code action "Add 2 required fields" to fill them in!
     app_name: "My App",
+
     // Required: version, features
     // The LSP should show: "2 Required fields: version, features"
     // Note: description in `Option` so it's optional.

--- a/example/data/test_struct_variant.ron
+++ b/example/data/test_struct_variant.ron
@@ -1,0 +1,3 @@
+/* @[crate::models::Status] */
+
+Processing ( progress: 50, stage: "building" )

--- a/example/data/test_struct_variant.ron
+++ b/example/data/test_struct_variant.ron
@@ -1,3 +1,5 @@
 /* @[crate::models::Status] */
-
-Processing ( progress: 50, stage: "building" )
+Processing (
+    progress: 50,
+    stage: "building",
+)

--- a/example/data/user.ron
+++ b/example/data/user.ron
@@ -1,11 +1,15 @@
 /* @[crate::models::User] */
-
 User(
     id: 1,
     name: "Alice Johnson",
     email: "alice@example.com",
     age: 28,
-    bio: Some("Full-stack developer passionate about Rust and web technologies."),
+    bio: Some(
+        "Full-stack developer passionate about Rust and web technologies.",
+    ),
     is_active: true,
-    roles: ["admin", "developer"],
+    roles: [
+        "admin",
+        "developer",
+    ],
 )

--- a/example/src/models.rs
+++ b/example/src/models.rs
@@ -30,6 +30,8 @@ pub struct User {
 pub enum PostType {
     Short,
     Long,
+    Described(String),
+    Detailed { length: usize }
 }
 
 /// A blog post
@@ -163,4 +165,65 @@ pub struct GenericTest {
 
     /// Bad: Should be Box<u32> but will receive wrong type
     pub bad_box: Box<u32>,
+}
+
+/// Status enum with different variant types for testing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Status {
+    /// A simple unit variant
+    Active,
+
+    /// A unit variant for inactive state
+    Inactive,
+
+    /// A tuple variant with a single u32 reason code
+    Error(u32),
+
+    /// A tuple variant with message
+    Warning(String),
+
+    /// A struct-like variant with named fields
+    Processing { progress: u32, stage: String },
+}
+
+/// Message enum demonstrating nested types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Message {
+    /// Simple text message
+    Text(String),
+
+    /// Image with URL and optional caption
+    Image { url: String, caption: Option<String> },
+
+    /// Post reference containing nested Post struct
+    PostReference(Post),
+
+    /// Multiple users tagged
+    UserTag(Vec<User>),
+}
+
+/// Product for demonstrating unnamed struct syntax
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Product {
+    /// Product ID
+    pub id: u32,
+
+    /// Product name
+    pub name: String,
+
+    /// Price in cents
+    pub price: u32,
+
+    /// Nested manufacturer info
+    pub manufacturer: Manufacturer,
+}
+
+/// Manufacturer information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manufacturer {
+    /// Manufacturer name
+    pub name: String,
+
+    /// Country of origin
+    pub country: String,
 }

--- a/src/code_actions.rs
+++ b/src/code_actions.rs
@@ -1,0 +1,594 @@
+use crate::ron_parser;
+use crate::rust_analyzer::{FieldInfo, TypeInfo};
+use tower_lsp::lsp_types::*;
+
+/// Generate all code actions for a RON document
+pub fn generate_code_actions(
+    content: &str,
+    type_info: &TypeInfo,
+    uri: &str,
+) -> Vec<CodeActionOrCommand> {
+    let mut actions = Vec::new();
+
+    // Add actions for making struct names explicit
+    actions.extend(generate_explicit_type_actions(content, type_info, uri));
+
+    // Add actions for missing fields (only for structs)
+    if let Some(fields) = type_info.fields() {
+        actions.extend(generate_missing_field_actions(
+            content, fields, type_info, uri,
+        ));
+    }
+
+    actions
+}
+
+/// Generate code actions for making implicit struct names explicit
+fn generate_explicit_type_actions(
+    content: &str,
+    type_info: &TypeInfo,
+    uri: &str,
+) -> Vec<CodeActionOrCommand> {
+    let mut actions = Vec::new();
+
+    // Check if the root level uses unnamed struct syntax
+    if let Some(action) = create_explicit_root_type_action(content, type_info, uri) {
+        actions.push(action);
+    }
+
+    // Check for nested unnamed structs in field values
+    if let Some(fields) = type_info.fields() {
+        for field in fields {
+            if let Some(action) = create_explicit_field_type_action(content, field, uri) {
+                actions.push(action);
+            }
+        }
+    }
+
+    actions
+}
+
+/// Generate code actions for adding missing fields
+fn generate_missing_field_actions(
+    content: &str,
+    fields: &[FieldInfo],
+    type_info: &TypeInfo,
+    uri: &str,
+) -> Vec<CodeActionOrCommand> {
+    let mut actions = Vec::new();
+
+    let ron_fields = ron_parser::extract_fields_from_ron(content);
+
+    // Find missing fields
+    let all_missing: Vec<_> = fields
+        .iter()
+        .filter(|field| !ron_fields.contains(&field.name))
+        .collect();
+
+    // Find required missing fields (not Option<T> and no Default trait)
+    let required_missing: Vec<_> = all_missing
+        .iter()
+        .filter(|&&field| !field.type_name.starts_with("Option") && !type_info.has_default)
+        .copied()
+        .collect();
+
+    // Code action: Add all required fields
+    if !required_missing.is_empty() {
+        if let Some(edit) = generate_field_insertions(&required_missing, content) {
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(
+                tower_lsp::lsp_types::Url::parse(uri).unwrap(),
+                vec![edit],
+            );
+
+            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!(
+                    "Add {} required field{}",
+                    required_missing.len(),
+                    if required_missing.len() == 1 { "" } else { "s" }
+                ),
+                kind: Some(CodeActionKind::QUICKFIX),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        }
+    }
+
+    // Code action: Add all fields
+    if !all_missing.is_empty() {
+        if let Some(edit) = generate_field_insertions(&all_missing, content) {
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(
+                tower_lsp::lsp_types::Url::parse(uri).unwrap(),
+                vec![edit],
+            );
+
+            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!(
+                    "Add all {} missing field{}",
+                    all_missing.len(),
+                    if all_missing.len() == 1 { "" } else { "s" }
+                ),
+                kind: Some(CodeActionKind::QUICKFIX),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        }
+    }
+
+    actions
+}
+
+/// Create action to make root-level struct name explicit
+/// Converts: `(field: value)` → `StructName(field: value)`
+fn create_explicit_root_type_action(
+    content: &str,
+    type_info: &TypeInfo,
+    uri: &str,
+) -> Option<CodeActionOrCommand> {
+    // Check if content starts with unnamed struct syntax
+    for (line_num, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("//") || trimmed.starts_with("/*") {
+            continue;
+        }
+
+        // If it starts with '(' without a type name, offer to add one
+        if trimmed.starts_with('(') {
+            let type_name = type_info
+                .name
+                .split("::")
+                .last()
+                .unwrap_or(&type_info.name);
+
+            // Find the position of '(' in the original line (accounting for leading whitespace)
+            let leading_whitespace = line.len() - line.trim_start().len();
+            let paren_pos = leading_whitespace;
+
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(
+                tower_lsp::lsp_types::Url::parse(uri).unwrap(),
+                vec![TextEdit {
+                    range: Range::new(
+                        Position::new(line_num as u32, paren_pos as u32),
+                        Position::new(line_num as u32, paren_pos as u32),
+                    ),
+                    new_text: type_name.to_string(),
+                }],
+            );
+
+            return Some(CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Make struct name explicit: {}", type_name),
+                kind: Some(CodeActionKind::REFACTOR),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        }
+
+        break; // Only check first non-comment line
+    }
+
+    None
+}
+
+/// Create action to make nested field type explicit
+/// Converts: `foo: (value)` → `foo: TypeName(value)`
+fn create_explicit_field_type_action(
+    content: &str,
+    field: &FieldInfo,
+    uri: &str,
+) -> Option<CodeActionOrCommand> {
+    // Find the field in the content
+    let field_pattern = format!("{}:", field.name);
+    let field_pos = content.find(&field_pattern)?;
+
+    // Find where the value starts (after colon)
+    let after_field = &content[field_pos + field_pattern.len()..];
+    let value_start_in_after = after_field.len() - after_field.trim_start().len();
+    let value_str = after_field[value_start_in_after..].trim_start();
+
+    // Check if the value starts with '(' (unnamed struct/tuple)
+    if value_str.starts_with('(') {
+        // Check if it's already explicitly typed by looking for TypeName(
+        // We need to check if there's a type name before the paren
+        let before_paren = &after_field[value_start_in_after..]
+            .split('(')
+            .next()
+            .unwrap_or("");
+
+        if before_paren.trim().is_empty() {
+            // It's unnamed! Offer to add the type name
+            let type_name = field
+                .type_name
+                .split("::")
+                .last()
+                .unwrap_or(&field.type_name)
+                .replace(" ", "");
+
+            // Strip Option< > and other wrappers
+            let clean_type = if type_name.starts_with("Option<") && type_name.ends_with('>') {
+                &type_name[7..type_name.len() - 1]
+            } else {
+                &type_name
+            };
+
+            // Calculate the byte offset of the opening paren in the entire content
+            let paren_offset = field_pos + field_pattern.len() + value_start_in_after;
+
+            // Convert byte offset to line/column position
+            let before_paren_content = &content[..paren_offset];
+            // Count newlines to get 0-indexed line number
+            let paren_line_num = before_paren_content.matches('\n').count();
+            let line_start_offset = before_paren_content.rfind('\n').map(|pos| pos + 1).unwrap_or(0);
+            let paren_col = paren_offset - line_start_offset;
+
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(
+                tower_lsp::lsp_types::Url::parse(uri).unwrap(),
+                vec![TextEdit {
+                    range: Range::new(
+                        Position::new(paren_line_num as u32, paren_col as u32),
+                        Position::new(paren_line_num as u32, paren_col as u32),
+                    ),
+                    new_text: clean_type.to_string(),
+                }],
+            );
+
+            return Some(CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Make field type explicit: {} {}", field.name, clean_type),
+                kind: Some(CodeActionKind::REFACTOR),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }));
+        }
+    }
+
+    None
+}
+
+/// Generate text edits to insert missing fields
+fn generate_field_insertions(missing_fields: &[&FieldInfo], content: &str) -> Option<TextEdit> {
+    // Find the insertion point - right before the closing parenthesis
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Find the last line with content (before the closing paren)
+    let mut insert_line = 0;
+    let mut insert_col = 0;
+    let mut found_opening = false;
+
+    for (line_num, line) in lines.iter().enumerate() {
+        if line.contains('(') {
+            found_opening = true;
+        }
+        if found_opening && line.contains(')') {
+            insert_line = line_num;
+            // Find the position of the closing paren
+            insert_col = line.find(')').unwrap_or(0);
+            break;
+        }
+    }
+
+    if !found_opening {
+        return None;
+    }
+
+    // Check if we need to add a comma before our new fields
+    let needs_comma = if insert_line > 0 {
+        let prev_line = lines[insert_line.saturating_sub(1)].trim();
+        !prev_line.is_empty() && !prev_line.ends_with(',') && !prev_line.ends_with('(')
+    } else {
+        false
+    };
+
+    // Generate the field text
+    let mut field_text = String::new();
+    if needs_comma {
+        field_text.push_str(",\n");
+    } else if insert_line > 0 {
+        field_text.push('\n');
+    }
+
+    // Detect indentation from existing content
+    let indent = if let Some(line_with_field) = lines
+        .iter()
+        .find(|l| l.contains(':') && !l.trim().starts_with("/*"))
+    {
+        let trimmed = line_with_field.trim_start();
+        &line_with_field[..line_with_field.len() - trimmed.len()]
+    } else {
+        "    " // default to 4 spaces
+    };
+
+    for (i, field) in missing_fields.iter().enumerate() {
+        field_text.push_str(indent);
+        field_text.push_str(&field.name);
+        field_text.push_str(": ");
+        field_text.push_str(&generate_default_value(&field.type_name));
+        if i < missing_fields.len() - 1 {
+            field_text.push(',');
+        }
+        field_text.push('\n');
+    }
+
+    Some(TextEdit {
+        range: Range::new(
+            Position::new(insert_line as u32, insert_col as u32),
+            Position::new(insert_line as u32, insert_col as u32),
+        ),
+        new_text: field_text,
+    })
+}
+
+/// Generate a default value for a given Rust type
+fn generate_default_value(type_name: &str) -> String {
+    let clean = type_name.replace(" ", "");
+
+    if clean.starts_with("Option") {
+        "None".to_string()
+    } else if clean == "bool" {
+        "false".to_string()
+    } else if clean.starts_with("Vec") || clean.starts_with("[") {
+        "[]".to_string()
+    } else if clean.starts_with("HashMap") || clean.starts_with("BTreeMap") {
+        "{}".to_string()
+    } else if clean == "String" || clean == "&str" || clean == "str" {
+        "\"\"".to_string()
+    } else if clean.chars().all(|c| c.is_numeric() || c == 'i' || c == 'u' || c == 'f') {
+        // Numeric types
+        "0".to_string()
+    } else {
+        // Custom type - use constructor notation with placeholder
+        format!("{}()", clean)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rust_analyzer::TypeKind;
+
+    #[test]
+    fn test_explicit_root_type_same_line() {
+        let content = "(id: 1, name: \"test\")";
+        let type_info = TypeInfo {
+            name: "User".to_string(),
+            kind: TypeKind::Struct(vec![]),
+            docs: None,
+            source_file: None,
+            line: None,
+            column: None,
+            has_default: false,
+        };
+        let uri = "file:///test.ron";
+
+        let action = create_explicit_root_type_action(content, &type_info, uri);
+        assert!(action.is_some());
+
+        if let Some(CodeActionOrCommand::CodeAction(action)) = action {
+            assert_eq!(action.title, "Make struct name explicit: User");
+            let edit = action.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let text_edits = changes.values().next().unwrap();
+            assert_eq!(text_edits.len(), 1);
+            assert_eq!(text_edits[0].new_text, "User");
+            assert_eq!(text_edits[0].range.start.line, 0);
+            assert_eq!(text_edits[0].range.start.character, 0);
+        }
+    }
+
+    #[test]
+    fn test_explicit_root_type_next_line() {
+        let content = "(\n    id: 1,\n    name: \"test\"\n)";
+        let type_info = TypeInfo {
+            name: "example::User".to_string(),
+            kind: TypeKind::Struct(vec![]),
+            docs: None,
+            source_file: None,
+            line: None,
+            column: None,
+            has_default: false,
+        };
+        let uri = "file:///test.ron";
+
+        let action = create_explicit_root_type_action(content, &type_info, uri);
+        assert!(action.is_some());
+
+        if let Some(CodeActionOrCommand::CodeAction(action)) = action {
+            assert_eq!(action.title, "Make struct name explicit: User");
+            let edit = action.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let text_edits = changes.values().next().unwrap();
+            assert_eq!(text_edits.len(), 1);
+            assert_eq!(text_edits[0].new_text, "User");
+            assert_eq!(text_edits[0].range.start.line, 0);
+            assert_eq!(text_edits[0].range.start.character, 0);
+        }
+    }
+
+    #[test]
+    fn test_explicit_field_type_same_line() {
+        let content = "User(author: (id: 1, name: \"test\"))";
+        let field = FieldInfo {
+            name: "author".to_string(),
+            type_name: "Author".to_string(),
+            docs: None,
+            line: None,
+            column: None,
+        };
+        let uri = "file:///test.ron";
+
+        let action = create_explicit_field_type_action(content, &field, uri);
+        assert!(action.is_some());
+
+        if let Some(CodeActionOrCommand::CodeAction(action)) = action {
+            assert_eq!(action.title, "Make field type explicit: author Author");
+            let edit = action.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let text_edits = changes.values().next().unwrap();
+            assert_eq!(text_edits.len(), 1);
+            assert_eq!(text_edits[0].new_text, "Author");
+            // Should insert before the opening paren after "author: "
+            assert_eq!(text_edits[0].range.start.line, 0);
+            assert_eq!(text_edits[0].range.start.character, 13); // position of '(' after "author: "
+        }
+    }
+
+    #[test]
+    fn test_explicit_field_type_next_line() {
+        let content = r#"Post(
+    author: (
+        id: 5,
+        name: "Charlie",
+        email: "charlie@example.com"
+    )
+)"#;
+        let field = FieldInfo {
+            name: "author".to_string(),
+            type_name: "User".to_string(),
+            docs: None,
+            line: None,
+            column: None,
+        };
+        let uri = "file:///test.ron";
+
+        let action = create_explicit_field_type_action(content, &field, uri);
+        assert!(action.is_some());
+
+        if let Some(CodeActionOrCommand::CodeAction(action)) = action {
+            assert_eq!(action.title, "Make field type explicit: author User");
+            let edit = action.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let text_edits = changes.values().next().unwrap();
+            assert_eq!(text_edits.len(), 1);
+            assert_eq!(text_edits[0].new_text, "User");
+            // Should insert at the opening paren on line 1
+            assert_eq!(text_edits[0].range.start.line, 1);
+            assert_eq!(text_edits[0].range.start.character, 12); // position of '(' on second line
+        }
+    }
+
+    #[test]
+    fn test_explicit_field_type_with_option_wrapper() {
+        let content = "User(author: (id: 1, name: \"test\"))";
+        let field = FieldInfo {
+            name: "author".to_string(),
+            type_name: "Option<Author>".to_string(),
+            docs: None,
+            line: None,
+            column: None,
+        };
+        let uri = "file:///test.ron";
+
+        let action = create_explicit_field_type_action(content, &field, uri);
+        assert!(action.is_some());
+
+        if let Some(CodeActionOrCommand::CodeAction(action)) = action {
+            assert_eq!(action.title, "Make field type explicit: author Author");
+            let edit = action.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let text_edits = changes.values().next().unwrap();
+            assert_eq!(text_edits[0].new_text, "Author"); // Should strip Option wrapper
+        }
+    }
+
+    #[test]
+    fn test_no_action_for_explicit_type() {
+        let content = "User(id: 1, name: \"test\")";
+        let type_info = TypeInfo {
+            name: "User".to_string(),
+            kind: TypeKind::Struct(vec![]),
+            docs: None,
+            source_file: None,
+            line: None,
+            column: None,
+            has_default: false,
+        };
+        let uri = "file:///test.ron";
+
+        // Should not offer action since type is already explicit
+        let action = create_explicit_root_type_action(content, &type_info, uri);
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn test_no_action_for_explicit_field_type() {
+        let content = "User(author: Author(id: 1, name: \"test\"))";
+        let field = FieldInfo {
+            name: "author".to_string(),
+            type_name: "Author".to_string(),
+            docs: None,
+            line: None,
+            column: None,
+        };
+        let uri = "file:///test.ron";
+
+        // Should not offer action since field type is already explicit
+        let action = create_explicit_field_type_action(content, &field, uri);
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn test_real_world_with_comments_and_spacing() {
+        let content = r#"Post(
+    id: 123,
+    title: "Mixed Syntax Example",
+    content: "Demonstrating both explicit and unnamed struct syntax",
+
+    // Explicit type name for author
+    author: (
+        id: 5,
+        name: "Charlie",
+        email: "charlie@example.com",
+        age: 28,
+        bio: None,
+        is_active: true,
+        roles: ["editor"],
+    ),
+
+    likes: 50,
+    tags: ["example", "syntax"],
+    published: true,
+    post_type: Short,
+)"#;
+        let field = FieldInfo {
+            name: "author".to_string(),
+            type_name: "User".to_string(),
+            docs: None,
+            line: None,
+            column: None,
+        };
+        let uri = "file:///test.ron";
+
+        let action = create_explicit_field_type_action(content, &field, uri);
+        assert!(action.is_some());
+
+        if let Some(CodeActionOrCommand::CodeAction(action)) = action {
+            assert_eq!(action.title, "Make field type explicit: author User");
+            let edit = action.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let text_edits = changes.values().next().unwrap();
+            assert_eq!(text_edits.len(), 1);
+            assert_eq!(text_edits[0].new_text, "User");
+            // The opening paren is on line 6 (0-indexed), after the comment
+            assert_eq!(text_edits[0].range.start.line, 6);
+            // The opening paren is at column 12 (after "    author: ")
+            assert_eq!(text_edits[0].range.start.character, 12);
+
+            println!("Line: {}, Character: {}",
+                text_edits[0].range.start.line,
+                text_edits[0].range.start.character);
+        }
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,297 @@
+/// Simple RON formatter that handles:
+/// - Indentation based on (), [], {} nesting
+/// - Whitespace normalization
+/// - Comma placement
+/// - Preserves comments
+/// - Always multi-line for non-empty structures
+pub fn format_ron(content: &str) -> String {
+    // Extract type annotation if present
+    let has_annotation = content.trim_start().starts_with("/*");
+    let (annotation, ron_content) = if has_annotation {
+        if let Some(end_idx) = content.find("*/") {
+            let annotation = &content[..end_idx + 2];
+            let rest = &content[end_idx + 2..];
+            (Some(annotation.trim()), rest)
+        } else {
+            (None, content)
+        }
+    } else {
+        (None, content)
+    };
+
+    let mut result = String::new();
+    let mut indent_level = 0;
+    let indent_str = "    "; // 4 spaces
+    let mut chars = ron_content.chars().peekable();
+    let mut in_string = false;
+    let mut escape_next = false;
+    let mut in_comment = false;
+    let mut current_line = String::new();
+    let mut at_line_start = true;
+    let mut bracket_depth: usize = 0; // Track nesting depth to know if we're in multi-line mode
+
+    while let Some(ch) = chars.next() {
+        // Handle line comments
+        if !in_string && ch == '/' && chars.peek() == Some(&'/') {
+            if !current_line.trim().is_empty() {
+                result.push_str(&indent_str.repeat(indent_level));
+                result.push_str(current_line.trim());
+                result.push('\n');
+                current_line.clear();
+            }
+
+            // Add blank line before comment if it's on its own line
+            // (at_line_start means we haven't accumulated content on this line yet)
+            // But don't add if it's right after an opening bracket (first field)
+            // or if the previous line was already a comment
+            let prev_line_was_comment = result
+                .trim_end()
+                .lines()
+                .last()
+                .map(|line| line.trim_start().starts_with("//"))
+                .unwrap_or(false);
+
+            if at_line_start
+                && !result.is_empty()
+                && !result.ends_with("\n\n")
+                && !result.ends_with("(\n")
+                && !result.ends_with("[\n")
+                && !result.ends_with("{\n")
+                && !prev_line_was_comment
+            {
+                result.push('\n');
+            }
+
+            current_line.push(ch);
+            in_comment = true;
+            continue;
+        }
+
+        if in_comment {
+            current_line.push(ch);
+            if ch == '\n' {
+                result.push_str(&indent_str.repeat(indent_level));
+                result.push_str(current_line.trim());
+                result.push('\n');
+                current_line.clear();
+                in_comment = false;
+                at_line_start = true;
+            }
+            continue;
+        }
+
+        // Handle strings
+        if in_string {
+            current_line.push(ch);
+            if escape_next {
+                escape_next = false;
+            } else if ch == '\\' {
+                escape_next = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                current_line.push(ch);
+            }
+            '(' | '[' | '{' => {
+                current_line.push(ch);
+
+                // Check if empty (e.g., "()", "[]")
+                let mut peek_chars = chars.clone();
+                let mut is_empty = true;
+                while let Some(&peek_ch) = peek_chars.peek() {
+                    if peek_ch.is_whitespace() {
+                        peek_chars.next();
+                    } else {
+                        is_empty = peek_ch == ')' || peek_ch == ']' || peek_ch == '}';
+                        break;
+                    }
+                }
+
+                if !is_empty {
+                    // Multi-line: write current line and indent
+                    result.push_str(&indent_str.repeat(indent_level));
+                    result.push_str(current_line.trim());
+                    result.push('\n');
+                    current_line.clear();
+                    indent_level += 1;
+                    bracket_depth += 1;
+                    at_line_start = true;
+                }
+                // If empty, stay on same line - current_line still has the opening bracket
+            }
+            ')' | ']' | '}' => {
+                // Check if we're in multi-line mode (bracket_depth > 0)
+                let is_multi_line = bracket_depth > 0;
+
+                if !is_multi_line {
+                    // Single-line mode (empty parens): just append closing bracket
+                    current_line.push(ch);
+                } else {
+                    // Multi-line mode: flush any content, dedent, and write closing bracket
+                    if !current_line.trim().is_empty() {
+                        let line = current_line.trim();
+                        result.push_str(&indent_str.repeat(indent_level));
+                        result.push_str(line);
+                        // Add trailing comma if not already there
+                        if !line.ends_with(',') {
+                            result.push(',');
+                        }
+                        result.push('\n');
+                        current_line.clear();
+                    }
+
+                    // Dedent and write closing bracket
+                    indent_level = indent_level.saturating_sub(1);
+                    bracket_depth = bracket_depth.saturating_sub(1);
+                    result.push_str(&indent_str.repeat(indent_level));
+                    result.push(ch);
+
+                    // Check if there's a trailing comma after the closing bracket in input
+                    let mut peek_chars = chars.clone();
+                    let mut found_comma = false;
+                    while let Some(&peek_ch) = peek_chars.peek() {
+                        if peek_ch == ',' {
+                            found_comma = true;
+                            break;
+                        } else if !peek_ch.is_whitespace() {
+                            break;
+                        }
+                        peek_chars.next();
+                    }
+
+                    if found_comma {
+                        // Consume whitespace and comma from input
+                        while let Some(&peek_ch) = chars.peek() {
+                            if peek_ch == ',' {
+                                chars.next();
+                                result.push(',');
+                                break;
+                            } else if peek_ch.is_whitespace() {
+                                chars.next();
+                            } else {
+                                break;
+                            }
+                        }
+                    } else if bracket_depth > 0 {
+                        // Still nested - check if next non-whitespace is closing bracket
+                        let mut peek_chars2 = chars.clone();
+                        let mut next_is_closing = false;
+                        while let Some(&peek_ch) = peek_chars2.peek() {
+                            if peek_ch.is_whitespace() {
+                                peek_chars2.next();
+                            } else {
+                                next_is_closing =
+                                    peek_ch == ')' || peek_ch == ']' || peek_ch == '}';
+                                break;
+                            }
+                        }
+
+                        // Only add trailing comma if NOT followed by closing bracket
+                        // This avoids "Foo(Bar(...),)" syntax which is invalid in RON
+                        if !next_is_closing {
+                            result.push(',');
+                        }
+                    }
+
+                    result.push('\n');
+                    at_line_start = true;
+                }
+            }
+            ',' => {
+                current_line.push(ch);
+                result.push_str(&indent_str.repeat(indent_level));
+                result.push_str(current_line.trim());
+                result.push('\n');
+                current_line.clear();
+                at_line_start = true;
+            }
+            '\n' | '\r' => {
+                // Skip newlines, we'll add our own
+                if !current_line.trim().is_empty() && !at_line_start {
+                    current_line.push(' ');
+                }
+            }
+            c if c.is_whitespace() => {
+                if !current_line.trim().is_empty() && !current_line.ends_with(' ') {
+                    current_line.push(' ');
+                }
+            }
+            _ => {
+                current_line.push(ch);
+                at_line_start = false;
+            }
+        }
+    }
+
+    // Flush any remaining content
+    if !current_line.trim().is_empty() {
+        result.push_str(&indent_str.repeat(indent_level));
+        result.push_str(current_line.trim());
+        result.push('\n');
+    }
+
+    let formatted = result.trim_end().to_string();
+
+    // Add back annotation if present
+    if let Some(ann) = annotation {
+        format!("{}\n{}", ann, formatted)
+    } else {
+        formatted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_struct() {
+        let input = "User(id: 1, name: \"Alice\")";
+        let formatted = format_ron(input);
+        println!("Formatted:\n{}", formatted);
+        assert!(formatted.contains("User("));
+        assert!(formatted.contains("    id: 1,"));
+        assert!(formatted.contains("    name: \"Alice\","));
+        assert!(formatted.contains(")"));
+    }
+
+    #[test]
+    fn test_empty_parens() {
+        let input = "Unit()";
+        let formatted = format_ron(input);
+        println!("Formatted: '{}'", formatted);
+        // Empty parens stay on same line
+        assert!(formatted.starts_with("Unit()"));
+    }
+
+    #[test]
+    fn test_nested_struct() {
+        let input = "Post(author: User(id: 1))";
+        let formatted = format_ron(input);
+        println!("Formatted:\n{}", formatted);
+        assert!(formatted.contains("Post("));
+        assert!(formatted.contains("    author: User("));
+        assert!(formatted.contains("        id: 1,"));
+        // Conservative: no trailing comma when followed by closing bracket (avoids invalid syntax)
+        assert!(formatted.contains("    )"));
+        assert!(formatted.trim().ends_with(")"));
+    }
+
+    #[test]
+    fn test_array() {
+        let input = r#"Config(roles: ["admin", "user"])"#;
+        let formatted = format_ron(input);
+        println!("Formatted:\n{}", formatted);
+        assert!(formatted.contains("roles: ["));
+        assert!(formatted.contains(r#"        "admin","#));
+        assert!(formatted.contains(r#"        "user","#));
+        // Array closing bracket should be followed by comma on next line
+        assert!(formatted.contains("    ],") || formatted.contains("    ]\n)"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod annotation_parser;
+mod code_actions;
 mod completion;
 mod diagnostic_reporter;
 mod diagnostics;
@@ -17,6 +18,11 @@ use tower_lsp::{Client, LanguageServer, LspService, Server};
 pub struct Document {
     content: String,
     type_annotation: Option<String>,
+    // Cache the parsed RON value to avoid re-parsing
+    parsed_value_cache: Option<ron::Value>,
+    // Cache context lookups - map from (line, character) to type contexts
+    // We use a simple cache that stores recent lookups
+    context_cache: std::collections::HashMap<(u32, u32), Vec<ron_parser::TypeContext>>,
 }
 
 pub struct Backend {
@@ -32,6 +38,34 @@ impl Backend {
             documents: Arc::new(RwLock::new(HashMap::new())),
             rust_analyzer: Arc::new(rust_analyzer::RustAnalyzer::new()),
         }
+    }
+
+    /// Get type contexts with caching
+    async fn get_type_contexts(&self, uri: &str, position: Position, content: &str) -> Vec<ron_parser::TypeContext> {
+        let pos_key = (position.line, position.character);
+
+        // Try to get from cache first
+        {
+            let documents = self.documents.read().await;
+            if let Some(doc) = documents.get(uri) {
+                if let Some(cached) = doc.context_cache.get(&pos_key) {
+                    return cached.clone();
+                }
+            }
+        }
+
+        // Not in cache, compute it
+        let contexts = ron_parser::find_type_context_at_position(content, position);
+
+        // Store in cache
+        {
+            let mut documents = self.documents.write().await;
+            if let Some(doc) = documents.get_mut(uri) {
+                doc.context_cache.insert(pos_key, contexts.clone());
+            }
+        }
+
+        contexts
     }
 }
 
@@ -106,6 +140,8 @@ impl LanguageServer for Backend {
                 definition_provider: Some(OneOf::Left(true)),
                 rename_provider: Some(OneOf::Left(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                document_formatting_provider: Some(OneOf::Left(true)),
+                document_range_formatting_provider: Some(OneOf::Left(true)),
                 ..Default::default()
             },
             ..Default::default()
@@ -128,11 +164,16 @@ impl LanguageServer for Backend {
 
         let type_annotation = annotation_parser::parse_type_annotation(&content);
 
+        // Pre-parse RON for caching
+        let parsed_value_cache = ron::from_str::<ron::Value>(&content).ok();
+
         self.documents.write().await.insert(
             uri.clone(),
             Document {
                 content: content.clone(),
                 type_annotation: type_annotation.clone(),
+                parsed_value_cache,
+                context_cache: std::collections::HashMap::new(),
             },
         );
 
@@ -147,11 +188,16 @@ impl LanguageServer for Backend {
             let content = change.text;
             let type_annotation = annotation_parser::parse_type_annotation(&content);
 
+            // Pre-parse RON for caching
+            let parsed_value_cache = ron::from_str::<ron::Value>(&content).ok();
+
             self.documents.write().await.insert(
                 uri.clone(),
                 Document {
                     content: content.clone(),
                     type_annotation: type_annotation.clone(),
+                    parsed_value_cache,
+                    context_cache: std::collections::HashMap::new(),
                 },
             );
 
@@ -202,28 +248,62 @@ impl LanguageServer for Backend {
             .to_string();
         let position = params.text_document_position_params.position;
 
-        let documents = self.documents.read().await;
-        if let Some(doc) = documents.get(&uri) {
-            if let Some(type_path) = &doc.type_annotation {
-                if let Some(type_info) = self.rust_analyzer.get_type_info(type_path).await {
-                    if let Some(field_name) =
-                        ron_parser::get_field_at_position(&doc.content, position)
-                    {
-                        if let Some(fields) = type_info.fields() {
-                            if let Some(field) = fields.iter().find(|f| f.name == field_name) {
-                                return Ok(Some(Hover {
-                                    contents: HoverContents::Markup(MarkupContent {
-                                        kind: MarkupKind::Markdown,
-                                        value: format!(
-                                            "```rust\n{}: {}\n```\n\n{}",
-                                            field.name,
-                                            field.type_name,
-                                            field.docs.as_deref().unwrap_or("")
-                                        ),
-                                    }),
-                                    range: None,
-                                }));
+        // Get document data we need (clone to avoid holding lock during async operations)
+        let (content, type_path) = {
+            let documents = self.documents.read().await;
+            match documents.get(&uri) {
+                Some(doc) => (doc.content.clone(), doc.type_annotation.clone()),
+                None => return Ok(None),
+            }
+        };
+
+        if let Some(type_path) = type_path {
+            // Use cached context lookup
+            let contexts = self.get_type_contexts(&uri, position, &content).await;
+
+            // Start with the top-level type, then traverse nested contexts
+            let mut current_type_info = self.rust_analyzer.get_type_info(&type_path).await;
+
+                // Navigate through the nested contexts
+                for context in contexts.iter().skip(1) {
+                    // Skip first since it's the top-level type we already have
+                    if let Some(info) = current_type_info {
+                        // This context should be a field or variant in the current type
+                        // Try to find it and get its type
+                        if let Some(fields) = info.fields() {
+                            if let Some(field) = fields.iter().find(|f| f.type_name.contains(&context.type_name)) {
+                                current_type_info = self.rust_analyzer.get_type_info(&field.type_name).await;
+                                continue;
                             }
+                        }
+                        // Try as variant
+                        if let Some(variant) = info.find_variant(&context.type_name) {
+                            // For enum variants, we need to check the variant's fields
+                            current_type_info = Some(info); // Stay at enum level
+                            continue;
+                        }
+                        // Try getting the type directly
+                        current_type_info = self.rust_analyzer.get_type_info(&context.type_name).await;
+                    }
+                }
+
+            // Now use the innermost type context
+            if let Some(type_info) = current_type_info {
+                if let Some(field_name) = ron_parser::get_field_at_position(&content, position) {
+                    if let Some(fields) = type_info.fields() {
+                        if let Some(field) = fields.iter().find(|f| f.name == field_name) {
+                            return Ok(Some(Hover {
+                                contents: HoverContents::Markup(MarkupContent {
+                                    kind: MarkupKind::Markdown,
+                                    value: format!(
+                                        "```rust\n{}: {}\n```\n\n{}",
+                                        field.name,
+                                        field.type_name,
+                                        field.docs.as_deref().unwrap_or("")
+                                    ),
+                                }),
+                                range: None,
+                            }));
                         }
                     }
                 }
@@ -244,27 +324,49 @@ impl LanguageServer for Backend {
             .to_string();
         let position = params.text_document_position_params.position;
 
-        let documents = self.documents.read().await;
-        let doc = match documents.get(&uri) {
-            Some(d) => d,
-            None => return Ok(None),
+        // Get document data we need (clone to avoid holding lock during async operations)
+        let (content, type_path) = {
+            let documents = self.documents.read().await;
+            match documents.get(&uri) {
+                Some(doc) => (doc.content.clone(), doc.type_annotation.clone()),
+                None => return Ok(None),
+            }
         };
 
         // Get the word at cursor position - early return if none
-        let word = match get_word_at_position(&doc.content, position) {
+        let word = match get_word_at_position(&content, position) {
             Some(w) => w,
             None => return Ok(None),
         };
 
-        // If we have a type annotation, get the type info once
-        let type_info = if let Some(type_path) = &doc.type_annotation {
-            self.rust_analyzer.get_type_info(type_path).await
+        // If we have a type annotation, find the nested context
+        let mut current_type_info = if let Some(type_path) = type_path {
+            // Use cached context lookup
+            let contexts = self.get_type_contexts(&uri, position, &content).await;
+            let mut info = self.rust_analyzer.get_type_info(&type_path).await;
+
+            // Navigate through nested contexts to find the innermost type
+            for context in contexts.iter().skip(1) {
+                if let Some(current_info) = info {
+                    // Try to find the context type as a field's type
+                    if let Some(fields) = current_info.fields() {
+                        if let Some(field) = fields.iter().find(|f| f.type_name.contains(&context.type_name)) {
+                            info = self.rust_analyzer.get_type_info(&field.type_name).await;
+                            continue;
+                        }
+                    }
+                    // Try as direct type lookup
+                    info = self.rust_analyzer.get_type_info(&context.type_name).await;
+                }
+            }
+
+            info
         } else {
             None
         };
 
-        // Check if the word is a valid field name in this type
-        if let Some(ref info) = type_info {
+        // Check if the word is a valid field name in the current context type
+        if let Some(ref info) = current_type_info {
             if let Some(field) = info.find_field(&word) {
                 return create_location_response(&info.source_file, field.line, field.column);
             }
@@ -281,7 +383,7 @@ impl LanguageServer for Backend {
 
             // Check if we're on a field, and if the word is a variant of that field's type
             // e.g., in "post_type: Short", if cursor is near Short, check if it's a variant of PostType
-            if let Some(field_name) = ron_parser::get_field_at_position(&doc.content, position) {
+            if let Some(field_name) = ron_parser::get_field_at_position(&content, position) {
                 if let Some(field) = info.find_field(&field_name) {
                     // Get the type of this specific field
                     if let Some(field_type_info) =
@@ -360,78 +462,11 @@ impl LanguageServer for Backend {
         if let Some(doc) = documents.get(&uri) {
             if let Some(type_path) = &doc.type_annotation {
                 if let Some(type_info) = self.rust_analyzer.get_type_info(type_path).await {
-                    // Only provide code actions for structs
-                    if let Some(fields) = type_info.fields() {
-                        let ron_fields = ron_parser::extract_fields_from_ron(&doc.content);
+                    let actions =
+                        code_actions::generate_code_actions(&doc.content, &type_info, &uri);
 
-                        // Find missing fields
-                        let all_missing: Vec<_> = fields
-                            .iter()
-                            .filter(|field| !ron_fields.contains(&field.name))
-                            .collect();
-
-                        // Find required missing fields (not Option<T> and no Default trait)
-                        let required_missing: Vec<_> = all_missing
-                            .iter()
-                            .filter(|&&field| !field.type_name.starts_with("Option") && !type_info.has_default)
-                            .copied()
-                            .collect();
-
-                        let mut actions = Vec::new();
-
-                        // Code action: Add all required fields
-                        if !required_missing.is_empty() {
-                            let new_text = generate_field_insertions(&required_missing, &doc.content);
-                            if let Some(edit) = new_text {
-                                let mut changes = std::collections::HashMap::new();
-                                changes.insert(
-                                    tower_lsp::lsp_types::Url::parse(&uri).unwrap(),
-                                    vec![edit],
-                                );
-
-                                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                                    title: format!("Add {} required field{}",
-                                        required_missing.len(),
-                                        if required_missing.len() == 1 { "" } else { "s" }
-                                    ),
-                                    kind: Some(CodeActionKind::QUICKFIX),
-                                    edit: Some(WorkspaceEdit {
-                                        changes: Some(changes),
-                                        ..Default::default()
-                                    }),
-                                    ..Default::default()
-                                }));
-                            }
-                        }
-
-                        // Code action: Add all fields
-                        if !all_missing.is_empty() {
-                            let new_text = generate_field_insertions(&all_missing, &doc.content);
-                            if let Some(edit) = new_text {
-                                let mut changes = std::collections::HashMap::new();
-                                changes.insert(
-                                    tower_lsp::lsp_types::Url::parse(&uri).unwrap(),
-                                    vec![edit],
-                                );
-
-                                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                                    title: format!("Add all {} missing field{}",
-                                        all_missing.len(),
-                                        if all_missing.len() == 1 { "" } else { "s" }
-                                    ),
-                                    kind: Some(CodeActionKind::QUICKFIX),
-                                    edit: Some(WorkspaceEdit {
-                                        changes: Some(changes),
-                                        ..Default::default()
-                                    }),
-                                    ..Default::default()
-                                }));
-                            }
-                        }
-
-                        if !actions.is_empty() {
-                            return Ok(Some(actions));
-                        }
+                    if !actions.is_empty() {
+                        return Ok(Some(actions));
                     }
                 }
             }
@@ -439,98 +474,81 @@ impl LanguageServer for Backend {
 
         Ok(None)
     }
-}
 
-fn generate_field_insertions(missing_fields: &[&rust_analyzer::FieldInfo], content: &str) -> Option<TextEdit> {
-    // Find the insertion point - right before the closing parenthesis
-    let lines: Vec<&str> = content.lines().collect();
+    async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
+        let uri = params.text_document.uri.to_string();
 
-    // Find the last line with content (before the closing paren)
-    let mut insert_line = 0;
-    let mut insert_col = 0;
-    let mut found_opening = false;
+        let documents = self.documents.read().await;
+        if let Some(doc) = documents.get(&uri) {
+            // Basic RON formatting: normalize whitespace and indentation
+            let formatted = Backend::format_ron(&doc.content);
 
-    for (line_num, line) in lines.iter().enumerate() {
-        if line.contains('(') {
-            found_opening = true;
+            if formatted != doc.content {
+                return Ok(Some(vec![TextEdit {
+                    range: Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
+                    new_text: formatted,
+                }]));
+            }
         }
-        if found_opening && line.contains(')') {
-            insert_line = line_num;
-            // Find the position of the closing paren
-            insert_col = line.find(')').unwrap_or(0);
-            break;
+
+        Ok(None)
+    }
+
+    async fn range_formatting(
+        &self,
+        params: DocumentRangeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let uri = params.text_document.uri.to_string();
+        let range = params.range;
+
+        let documents = self.documents.read().await;
+        if let Some(doc) = documents.get(&uri) {
+            // Extract the text in the range
+            let lines: Vec<&str> = doc.content.lines().collect();
+            let start_line = range.start.line as usize;
+            let end_line = range.end.line as usize;
+
+            if start_line < lines.len() && end_line < lines.len() {
+                // Get the selected text
+                let mut selected_text = String::new();
+                for (i, line) in lines
+                    .iter()
+                    .enumerate()
+                    .skip(start_line)
+                    .take(end_line - start_line + 1)
+                {
+                    if i == start_line && i == end_line {
+                        // Single line selection
+                        let start_char = range.start.character as usize;
+                        let end_char = range.end.character as usize;
+                        selected_text
+                            .push_str(&line[start_char.min(line.len())..end_char.min(line.len())]);
+                    } else if i == start_line {
+                        let start_char = range.start.character as usize;
+                        selected_text.push_str(&line[start_char.min(line.len())..]);
+                        selected_text.push('\n');
+                    } else if i == end_line {
+                        let end_char = range.end.character as usize;
+                        selected_text.push_str(&line[..end_char.min(line.len())]);
+                    } else {
+                        selected_text.push_str(line);
+                        selected_text.push('\n');
+                    }
+                }
+
+                // Format the selected text
+                let formatted = Backend::format_ron(&selected_text);
+
+                if formatted != selected_text {
+                    return Ok(Some(vec![TextEdit {
+                        range,
+                        new_text: formatted,
+                    }]));
+                }
+            }
         }
-    }
 
-    if !found_opening {
-        return None;
-    }
-
-    // Check if we need to add a comma before our new fields
-    let needs_comma = if insert_line > 0 {
-        let prev_line = lines[insert_line.saturating_sub(1)].trim();
-        !prev_line.is_empty() && !prev_line.ends_with(',') && !prev_line.ends_with('(')
-    } else {
-        false
-    };
-
-    // Generate the field text
-    let mut field_text = String::new();
-    if needs_comma {
-        field_text.push_str(",\n");
-    } else if insert_line > 0 {
-        field_text.push('\n');
-    }
-
-    // Detect indentation from existing content
-    let indent = if let Some(line_with_field) = lines.iter()
-        .find(|l| l.contains(':') && !l.trim().starts_with("/*"))
-    {
-        let trimmed = line_with_field.trim_start();
-        &line_with_field[..line_with_field.len() - trimmed.len()]
-    } else {
-        "    " // default to 4 spaces
-    };
-
-    for (i, field) in missing_fields.iter().enumerate() {
-        field_text.push_str(indent);
-        field_text.push_str(&field.name);
-        field_text.push_str(": ");
-        field_text.push_str(&generate_default_value(&field.type_name));
-        if i < missing_fields.len() - 1 {
-            field_text.push(',');
-        }
-        field_text.push('\n');
-    }
-
-    Some(TextEdit {
-        range: Range::new(
-            Position::new(insert_line as u32, insert_col as u32),
-            Position::new(insert_line as u32, insert_col as u32),
-        ),
-        new_text: field_text,
-    })
-}
-
-fn generate_default_value(type_name: &str) -> String {
-    let clean = type_name.replace(" ", "");
-
-    if clean.starts_with("Option") {
-        "None".to_string()
-    } else if clean == "bool" {
-        "false".to_string()
-    } else if clean.starts_with("Vec") || clean.starts_with("[") {
-        "[]".to_string()
-    } else if clean.starts_with("HashMap") || clean.starts_with("BTreeMap") {
-        "{}".to_string()
-    } else if clean == "String" || clean == "&str" || clean == "str" {
-        "\"\"".to_string()
-    } else if clean.chars().all(|c| c.is_numeric() || c == 'i' || c == 'u' || c == 'f') {
-        // Numeric types
-        "0".to_string()
-    } else {
-        // Custom type - use constructor notation with placeholder
-        format!("{}()", clean)
+        Ok(None)
     }
 }
 
@@ -614,6 +632,49 @@ fn get_word_at_position(content: &str, position: Position) -> Option<String> {
 }
 
 impl Backend {
+    fn format_ron(content: &str) -> String {
+        use ron::ser::{to_string_pretty, PrettyConfig};
+
+        // Check if content starts with a type annotation comment
+        let has_annotation = content.trim_start().starts_with("/*");
+        let (annotation, ron_content) = if has_annotation {
+            // Find the end of the annotation comment
+            if let Some(end_idx) = content.find("*/") {
+                let annotation = &content[..end_idx + 2];
+                let rest = &content[end_idx + 2..];
+                (Some(annotation), rest)
+            } else {
+                (None, content)
+            }
+        } else {
+            (None, content)
+        };
+
+        // Try to parse and reformat the RON content
+        let formatted_ron = match ron::from_str::<ron::Value>(ron_content.trim()) {
+            Ok(value) => {
+                let config = PrettyConfig::new()
+                    .depth_limit(100)
+                    .separate_tuple_members(true)
+                    .enumerate_arrays(false)
+                    .compact_arrays(false);
+
+                to_string_pretty(&value, config).unwrap_or_else(|_| ron_content.to_string())
+            }
+            Err(_) => {
+                // If parsing fails, just return original content
+                ron_content.to_string()
+            }
+        };
+
+        // Reconstruct with annotation if present
+        if let Some(ann) = annotation {
+            format!("{}\n\n{}", ann.trim(), formatted_ron)
+        } else {
+            formatted_ron
+        }
+    }
+
     async fn publish_diagnostics(&self, uri: &str, content: &str, type_annotation: Option<&str>) {
         self.client
             .log_message(


### PR DESCRIPTION
- Adds the concept of an "initial scan" and locks everything until it's done. before there was a bunch of lock contention on `get_type_info`
- Adds formatting
- Adds support for not specifying a type for a struct - like just doing `( ... )`
- Extracts code actions and adds the action to add the type to a non-typed struct.
- Add nested support on all LSP stuff (so like you actually get diagnostics / go to definition / hover / auto-complete, etc. on nested structures)