### PR TITLE
Add project wide configuration support through ron.toml file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "ariadne"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -305,6 +321,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +512,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lsp-types"
@@ -669,16 +704,21 @@ dependencies = [
 name = "ron-lsp"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "ariadne",
  "clap",
+ "globset",
  "lazy_static",
  "proc-macro2",
  "quote",
  "regex",
  "ron",
  "ron-lsp-tree-sitter",
+ "serde",
+ "serde_json",
  "syn",
  "tokio",
+ "toml",
  "tower-lsp",
  "tree-sitter",
  "walkdir",
@@ -766,6 +806,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -895,6 +944,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tower"
@@ -1156,6 +1244,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "ron-lsp"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0"
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 ron = "0.11"
@@ -22,6 +23,10 @@ regex = "1.10"
 lazy_static = "1.4"
 tree-sitter = "0.25.10"
 ron-lsp-tree-sitter = { version = "0.1.0", path = "tree-sitter-ron" }
+
+# config file
+toml = "0.9.8"
+globset = "0.4"
 
 # For Rust type analysis
 syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }
@@ -34,6 +39,8 @@ walkdir = "2.4"
 # For CLI (optional)
 clap = { version = "4.5", features = ["derive"], optional = true }
 ariadne = { version = "0.4", optional = true }
+serde_json = "1.0"
+serde = "1.0"
 
 [features]
 default = ["cli"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,40 @@ Config(
 
 <img width="707" height="436" alt="Screenshot 2025-10-24 at 5 52 13 PM" src="https://github.com/user-attachments/assets/f638947d-0408-4a7d-a209-de8e5d56c15d" />
 
+## ron.toml configuration
+
+You can configure default type mappings for RON files using an optional ron.toml file at your project root
+(next to Cargo.toml).
+
+This lets you omit the [Type Annotation](#type-annotation-format) in RON files whose paths match a glob pattern
+which is useful if you have multiple files with the same type (e.g., bevy assets).
+
+Example:
+
+```toml
+[[types]]
+# Matches all files named `post.ron`
+glob = "**/post.ron"
+# Fully qualified type name
+type = "crate::models::Post"
+
+[[types]]
+# Matches all files ron files in the `config` directory
+glob = "**/config/*.ron"
+type = "crate::models::Config"
+
+[[types]]
+# Matches all files ending with .user.ron
+glob = "**/*.user.ron"
+type = "crate::models::User"
+```
+
+### Precedence
+
+1. Type annotation in RON file
+2. Type declaration in ron.toml, declarations are tested in the order of the file
+
+
 ## Editor Integration
 
 Expand a section below for editor-specific instructions.

--- a/example/data/posts/introduction.post.ron
+++ b/example/data/posts/introduction.post.ron
@@ -1,0 +1,15 @@
+// No type annotation here, the type will be resolved from configuration in ron.toml
+Post(
+    id: 101,
+    title: "Getting Started with Rust",
+    content: "# Introduction to Rust\n\nRust is a systems programming language...",
+    author: 1,
+    likes: 42.0,
+    tags: [
+        "rust",
+        "programming",
+        "tutorial",
+    ],
+    post_type: Short,
+    foo: 1,
+)

--- a/example/data/posts/ownership.post.ron
+++ b/example/data/posts/ownership.post.ron
@@ -1,0 +1,15 @@
+Post(
+    id: 102,
+    title: "Ownership and Borrowing in Rust",
+    content: "# Ownership & Borrowing\n\nUnderstanding ownership is key to mastering Rust...",
+    author: 2,
+    likes: 58.0,
+    tags: [
+        "rust",
+        "ownership",
+        "borrowing",
+        "memory-safety",
+    ],
+    post_type: Long,
+    foo: 2,
+)

--- a/example/data/posts/tooling.post.ron
+++ b/example/data/posts/tooling.post.ron
@@ -1,0 +1,15 @@
+Post(
+    id: 103,
+    title: "Rust Tooling: Cargo and Crates.io",
+    content: "# Using Cargo\n\nCargo is Rust's package manager and build tool...",
+    author: 1,
+    likes: 37.5,
+    tags: [
+        "rust",
+        "cargo",
+        "tooling",
+        "package-management",
+    ],
+    post_type: Short,
+    foo: 3,
+)

--- a/example/ron.toml
+++ b/example/ron.toml
@@ -1,0 +1,5 @@
+[[types]]
+# Glob pattern used for matching
+glob = "**/*.post.ron"
+# Fully qualified type name
+type = "crate::models::Post"

--- a/src/code_actions.rs
+++ b/src/code_actions.rs
@@ -861,6 +861,7 @@ mod tests {
             client: client.clone(),
             documents: Default::default(),
             rust_analyzer: analyzer.clone(),
+            config: Arc::new(Default::default()),
         });
         let client = service.inner().client.clone();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,87 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use globset::{Glob, GlobMatcher};
+use serde::{Deserialize, Deserializer};
+
+pub const CONFIG_FILE_NAME: &str = "ron.toml";
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Config {
+    /// Map glob pattern to file path
+    #[serde(default)]
+    types: Vec<TypePattern>,
+
+    #[serde(default)]
+    pub root_dir: Option<PathBuf>,
+}
+
+impl Config {
+    /// Load config from the ron.toml file, if present. Returns the default config otherwise
+    pub fn try_load_from_dir<P: AsRef<Path>>(dir: P) -> anyhow::Result<Option<Self>> {
+        let path = dir.as_ref().join(CONFIG_FILE_NAME);
+
+        let config = if path.exists() && path.is_file() {
+            let text = fs::read_to_string(&path)?;
+            let mut config: Config = toml::from_str(&text)?;
+            config.root_dir.get_or_insert(PathBuf::from(dir.as_ref()));
+            Some(config)
+        } else {
+            None
+        };
+
+        Ok(config)
+    }
+
+    pub fn match_module_path<P: AsRef<Path>>(&self, file_path: P) -> Option<&String> {
+        let file_path = file_path.as_ref();
+        let rel = self
+            .root_dir
+            .as_ref()
+            .and_then(|root| file_path.strip_prefix(root).ok())
+            .unwrap_or(file_path);
+
+        self.types.iter().find_map(|TypePattern { glob, path }| {
+            if glob.is_match(rel) {
+                Some(path)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TypePattern {
+    #[serde(deserialize_with = "deserialize_glob")]
+    glob: GlobMatcher,
+    #[serde(rename = "type")]
+    path: String,
+}
+
+fn deserialize_glob<'de, D>(deserializer: D) -> Result<GlobMatcher, D::Error> where D: Deserializer<'de> {
+    String::deserialize(deserializer)
+        .and_then(|glob| Glob::new(&glob).map_err(serde::de::Error::custom))
+        .map(|glob| glob.compile_matcher())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_match_module_path() {
+        let config = Config {
+            types: vec![
+                TypePattern {
+                    glob: Glob::new("**/post.ron").unwrap().compile_matcher(),
+                    path: "crate::models::Post".to_string(),
+                }
+            ],
+            root_dir: Some("Bobby".into()),
+        };
+
+        let result = config.match_module_path(r#"MyDirectory\ron-lsp\example\data\post.ron"#);
+
+        assert_eq!(result, Some(&"crate::models::Post".to_string()));
+    }
+}


### PR DESCRIPTION
Add optional project-level configuration in a `ron.toml` file that defines a set of glob patterns to Rust type mappings.
These mappings are used for type resolution when the type annotation comment is absent in the RON file.

The configuration can be modified without restarting the LSP, though currently the affected RON file must be closed/reopened for it to be affected by the new configuration (I haven't yet figured out how to properly invalidate the cache on configuration change).

An invalid mapping in the configuration file is ignored without impact on the others.

Error reporting and autocompletion support for the configuration file is still to be done.

resolves #6
