### PR TITLE
Added support for default fields

### DIFF
--- a/example/src/models.rs
+++ b/example/src/models.rs
@@ -105,7 +105,7 @@ pub struct Config {
 }
 
 /// A settings struct without Default
-/// All non-Option fields are required in RON files
+/// All non-Option fields and fields not marked with `#[serde(default)]` are required in RON files
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
     /// Application name
@@ -118,6 +118,7 @@ pub struct Settings {
     pub description: Option<String>,
 
     /// Feature flags enabled
+    #[serde(default)]
     pub features: Vec<String>,
 }
 

--- a/src/code_actions.rs
+++ b/src/code_actions.rs
@@ -122,7 +122,7 @@ async fn generate_missing_variant_field_actions(
 
                     let required_missing: Vec<_> = missing_fields
                         .iter()
-                        .filter(|&&vfield| !vfield.type_name.starts_with("Option") && !field_type_info.has_default)
+                        .filter(|&&vfield| !vfield.is_optional() && !field_type_info.has_default)
                         .copied()
                         .collect();
 
@@ -213,7 +213,7 @@ fn generate_missing_field_actions(
 
                 let required_missing: Vec<_> = all_missing
                     .iter()
-                    .filter(|&&field| !field.type_name.starts_with("Option") && !type_info.has_default)
+                    .filter(|&&field| !field.is_optional() && !type_info.has_default)
                     .copied()
                     .collect();
 
@@ -286,7 +286,7 @@ fn generate_missing_field_actions(
     // Find required missing fields (not Option<T> and no Default trait)
     let required_missing: Vec<_> = all_missing
         .iter()
-        .filter(|&&field| !field.type_name.starts_with("Option") && !type_info.has_default)
+        .filter(|&&field| !field.is_optional() && !type_info.has_default)
         .copied()
         .collect();
 
@@ -644,6 +644,7 @@ mod tests {
             docs: None,
             line: None,
             column: None,
+            has_default: false,
         };
         let uri = "file:///test.ron";
 
@@ -678,6 +679,7 @@ mod tests {
             docs: None,
             line: None,
             column: None,
+            has_default: false,
         };
         let uri = "file:///test.ron";
 
@@ -706,6 +708,7 @@ mod tests {
             docs: None,
             line: None,
             column: None,
+            has_default: false,
         };
         let uri = "file:///test.ron";
 
@@ -749,6 +752,7 @@ mod tests {
             docs: None,
             line: None,
             column: None,
+            has_default: false,
         };
         let uri = "file:///test.ron";
 
@@ -786,6 +790,7 @@ mod tests {
             docs: None,
             line: None,
             column: None,
+            has_default: false,
         };
         let uri = "file:///test.ron";
 
@@ -823,6 +828,7 @@ mod tests {
                     docs: None,
                     line: Some(10),
                     column: Some(8),
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "field_b".to_string(),
@@ -830,6 +836,7 @@ mod tests {
                     docs: None,
                     line: Some(11),
                     column: Some(8),
+                    has_default: false,
                 },
             ],
             docs: None,

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -552,6 +552,7 @@ mod tests {
                     docs: Some("Field A documentation".to_string()),
                     line: Some(10),
                     column: Some(8),
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "field_b".to_string(),
@@ -559,6 +560,7 @@ mod tests {
                     docs: None,
                     line: Some(11),
                     column: Some(8),
+                    has_default: false,
                 },
             ],
             docs: Some("A struct variant".to_string()),
@@ -616,6 +618,7 @@ mod tests {
                 docs: None,
                 line: None,
                 column: None,
+                has_default: false,
             }],
             docs: Some("A tuple variant".to_string()),
             line: Some(10),

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -423,7 +423,7 @@ async fn validate_struct_fields(
         let missing_fields: Vec<_> = fields
             .iter()
             .filter(|field| {
-                !ron_fields.contains(&field.name) && !field.type_name.starts_with("Option")
+                !ron_fields.contains(&field.name) && !field.is_optional()
             })
             .collect();
 
@@ -584,7 +584,7 @@ async fn validate_node_with_type_info<'a>(
                 // Check for missing required fields
                 if !type_info.has_default {
                     for field in fields {
-                        if !present_fields.contains(&field.name) && !field.type_name.starts_with("Option") {
+                        if !present_fields.contains(&field.name) && !field.is_optional() {
                             let target_node = node.child(0).unwrap_or_else(|| *node);
                             let range = ts_utils::node_to_lsp_range(&target_node);
                             diagnostics.push(Diagnostic {
@@ -1438,6 +1438,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "title".to_string(),
@@ -1445,6 +1446,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "post_type".to_string(),
@@ -1452,6 +1454,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
             ]),
             docs: None,
@@ -1488,6 +1491,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "author".to_string(),
@@ -1495,6 +1499,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
             ]),
             docs: None,
@@ -1548,6 +1553,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "name".to_string(),
@@ -1555,6 +1561,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
             ]),
             docs: None,
@@ -1615,6 +1622,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "post_type".to_string(),
@@ -1622,6 +1630,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
             ]),
             docs: None,
@@ -1656,6 +1665,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "name".to_string(),
@@ -1663,6 +1673,7 @@ mod tests {
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
             ]),
             docs: None,
@@ -1700,6 +1711,7 @@ mod tests {
                         docs: None,
                         line: None,
                         column: None,
+                        has_default: false,
                     }],
                     docs: None,
                     line: None,
@@ -1713,6 +1725,7 @@ mod tests {
                         docs: None,
                         line: None,
                         column: None,
+                        has_default: false,
                     }],
                     docs: None,
                     line: None,
@@ -1761,6 +1774,7 @@ mod tests {
                         docs: None,
                         line: None,
                         column: None,
+                        has_default: false,
                     },
                     FieldInfo {
                         name: "sender".to_string(),
@@ -1768,6 +1782,7 @@ mod tests {
                         docs: None,
                         line: None,
                         column: None,
+                        has_default: false,
                     },
                 ],
                 docs: None,
@@ -1892,6 +1907,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "name".to_string(),
@@ -1899,6 +1915,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "email".to_string(),
@@ -1906,6 +1923,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "age".to_string(),
@@ -1913,6 +1931,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "is_active".to_string(),
@@ -1920,6 +1939,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
                 FieldInfo {
                     name: "roles".to_string(),
@@ -1927,6 +1947,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 },
             ]),
             docs: None,
@@ -1950,6 +1971,7 @@ PostReference(Post(
                     docs: None,
                     line: None,
                     column: None,
+                    has_default: false,
                 }],
                 docs: None,
                 line: None,


### PR DESCRIPTION
This PR adds basic support for treating fields with the `#[serde(default)]` and `#[serde(default = "...")]` attributes as optional. This is in addition to the existing default logic based on `Default` derives and `Option` types.

I kept the logic contained in a local module and such so that it would be ready to feature gate if necessary (I'm not super familiar with the project, so I'm not sure if I can add a new feature). Although, this technically shouldn't need a feature.

Let me know how you'd prefer to handle this and I can make whatever change you feel is best!