### PR TITLE
misc: Add `--version` support.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1635,7 +1635,7 @@ use clap::{Parser, Subcommand};
 #[cfg(feature = "cli")]
 #[derive(Parser)]
 #[command(name = "ron-lsp")]
-#[command(about = "LSP server and validator for RON files", long_about = None)]
+#[command(about = "LSP server and validator for RON files", long_about = None, version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
I tried packaging this for nix and noticed that the `--version` flag isn't supported.

Nix's default rust checks verify the program version matches, and I think it's better to support the flag than disable the check.


Also, I noticed that running `cargo fmt` changes a lot of things. I undid those changes, but it'd be nice if the code conformed to it as it's often the case that editors or pre-commit rules will run `cargo fmt` for you, which is often helpful, but not if there's changes on code you didn't touch.


---

I verified it locally, but couldn't bother to test it "properly".

```fish
cargo run -- --version
```

```console
   Compiling ron-lsp v0.1.1 (/tmp/ron-lsp)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.90s
     Running `target/debug/ron-lsp --version`
ron-lsp 0.1.1
```