### PR TITLE
Issue 18: Fix generic wrapped / nested type validation

### DIFF
--- a/example/src/models.rs
+++ b/example/src/models.rs
@@ -228,3 +228,24 @@ pub struct Manufacturer {
     /// Country of origin
     pub country: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vessel {
+    pub name: String,
+    pub symbol: char,
+    pub color: Color,
+    pub role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Color {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VesselsData {
+    pub vessels: Vec<Vessel>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ mod tests {
 
     #[test]
     fn test_match_module_path() {
+        // Use PathBuf::from components to build platform-appropriate paths
+        let root_dir: PathBuf = ["my", "project"].iter().collect();
         let config = Config {
             types: vec![
                 TypePattern {
@@ -77,11 +79,15 @@ mod tests {
                     path: "crate::models::Post".to_string(),
                 }
             ],
-            root_dir: Some("Bobby".into()),
+            root_dir: Some(root_dir.clone()),
         };
 
-        let result = config.match_module_path(r#"MyDirectory\ron-lsp\example\data\post.ron"#);
-
+        let matching_path: PathBuf = root_dir.join("example").join("data").join("post.ron");
+        let result = config.match_module_path(&matching_path);
         assert_eq!(result, Some(&"crate::models::Post".to_string()));
+
+        let non_matching_path: PathBuf = root_dir.join("example").join("data").join("user.ron");
+        let result = config.match_module_path(&non_matching_path);
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
- Fixes validation for nested types in generics
- Guard against byte_end <= byte_offset in ariadne spans (prevents panic)
- Handle multi-line LSP ranges when flattening to single-line portable diagnostics
- Check if a value is a valid enum variant before returning a basic type mismatch
    - fixes false positives like "expected PostType, got Detailed"
- Use end-of-first-line for multi-line value nodes to avoid inverted column ranges
- Also `cargo fmt`

## Fixes #18 

```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct Vessel {
    pub name: String,
    pub symbol: char,
    pub color: Color,
    pub role: String,
}

#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct Color {
    pub r: f32,
    pub g: f32,
    pub b: f32,
    pub a: f32,
}

#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct VesselsData {
    pub vessels: Vec<Vessel>,
}
```

```ron
/* @[crate::models::VesselsData] */

VesselsData(
    vessels: [
        Vessel(
            role: "General population",
        ),
        (
            role: "Industrial labor",
        )
    ]
)
```

### Ron LSP Validation

<img width="476" height="247" alt="Screenshot 2026-02-26 at 8 07 53 PM" src="https://github.com/user-attachments/assets/dc32af39-2066-4059-8236-524277006e5c" />

